### PR TITLE
74 fix 개인 정보 및 학생 정보 api 에러 해결

### DIFF
--- a/src/controllers/students.controller.js
+++ b/src/controllers/students.controller.js
@@ -45,7 +45,7 @@ class StudentsController {
   //특정 학생 정보 수정
   updateOneStudent = async (req, res, next) => {
     try {
-      const { studentId } = req.params;
+      const { studentId, schoolId } = req.params;
       const { name, grade, gradeClass, number } = req.body;
 
       const data = await this.studentsService.updateOneStudent(
@@ -54,6 +54,7 @@ class StudentsController {
         grade,
         gradeClass,
         number,
+        +schoolId,
       ); //받은 값들을 매개변수로 연결
 
       return res.status(HTTP_STATUS.OK).json({

--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -8,13 +8,14 @@ class UserController {
   assignHomeRoom = async (req, res, next) => {
     try {
       const userId = req.user.id;
-
+      const { schoolId } = req.params;
       const { grade, gradeClass } = req.body;
 
       const data = await this.userService.assignHomeRoom(
         grade,
         gradeClass,
         userId,
+        +schoolId,
       );
 
       return res.status(HTTP_STATUS.OK).json({

--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -66,6 +66,29 @@ class UserController {
       next(err);
     }
   };
+
+  // 내 정보 수정
+  updateMyInfo = async (req, res, next) => {
+    try {
+      const userId = req.user.id;
+      const { name, schoolName, profile } = req.body;
+
+      const data = await this.userService.updateMyInfo(
+        userId,
+        name,
+        schoolName,
+        profile,
+      );
+
+      return res.status(HTTP_STATUS.OK).json({
+        status: HTTP_STATUS.OK,
+        message: '내 정보 수정 성공',
+        data,
+      });
+    } catch (err) {
+      next(err);
+    }
+  };
 }
 
 export default UserController;

--- a/src/repositories/class.repository.js
+++ b/src/repositories/class.repository.js
@@ -36,6 +36,52 @@ class ClassRepository {
     });
     return data;
   };
+
+  // 담임 변경
+
+  updateHomeroom = async (classId, originalTeacherId, newTeacherId) => {
+    const data = await prisma.class.update({
+      where: {
+        classId,
+      },
+      data: {
+        teacherId: newTeacherId,
+      },
+    });
+
+    const originalTeacher = await prisma.teacher.update({
+      where: {
+        teacherId: originalTeacherId,
+      },
+      data: {
+        isHomeroom: false,
+      },
+    });
+
+    const newTeacher = await prisma.teacher.update({
+      where: {
+        teacherId: newTeacherId,
+      },
+      data: {
+        isHomeroom: true,
+      },
+    });
+
+    return data;
+  };
+
+  // 반 생성
+  createClass = async (grade, gradeClass, teacherId) => {
+    const data = await prisma.class.create({
+      data: {
+        grade,
+        gradeClass,
+        //반 테이블과 교사 테이블을 연결
+        teacherId,
+      },
+    });
+    return data;
+  };
 }
 
 export default ClassRepository;

--- a/src/repositories/class.repository.js
+++ b/src/repositories/class.repository.js
@@ -19,6 +19,23 @@ class ClassRepository {
     });
     return data;
   };
+
+  findClassByGradeAndClass = async (grade, gradeClass, schoolId) => {
+    const data = await prisma.class.findFirst({
+      where: {
+        grade,
+        gradeClass,
+        teacher: {
+          is: {
+            user: {
+              schoolId,
+            },
+          },
+        },
+      },
+    });
+    return data;
+  };
 }
 
 export default ClassRepository;

--- a/src/repositories/students.repository.js
+++ b/src/repositories/students.repository.js
@@ -52,7 +52,14 @@ class StudentsRepository {
   };
 
   //특정 학생 정보 수정
-  updateOneStudent = async (studentId, name, grade, gradeClass, number) => {
+  updateOneStudent = async (
+    studentId,
+    name,
+    grade,
+    gradeClass,
+    number,
+    classId,
+  ) => {
     const student = await prisma.student.update({
       where: {
         studentId: studentId,
@@ -63,6 +70,7 @@ class StudentsRepository {
         ...(grade && { grade: grade }),
         ...(gradeClass && { gradeClass: gradeClass }),
         ...(number && { number: number }),
+        ...(grade && classId && { classId: classId }),
       },
       include: {
         user: {

--- a/src/repositories/user.repository.js
+++ b/src/repositories/user.repository.js
@@ -13,19 +13,6 @@ class UserRepository {
     return data;
   };
 
-  // 반 생성
-  createClass = async (grade, gradeClass, teacherId) => {
-    const data = await prisma.class.create({
-      data: {
-        grade,
-        gradeClass,
-        //반 테이블과 교사 테이블을 연결
-        teacherId,
-      },
-    });
-    return data;
-  };
-
   // 내 정보 조회
   getUserById = async (userId, userRole) => {
     const user = await prisma.user.findUnique({

--- a/src/repositories/user.repository.js
+++ b/src/repositories/user.repository.js
@@ -83,5 +83,19 @@ class UserRepository {
     user.password = undefined;
     return user;
   };
+
+  // 내 정보 수정
+  updateMyInfo = async (userId, name, profile, schoolId) => {
+    console.log(schoolId);
+    const user = await prisma.user.update({
+      where: { id: userId },
+      data: {
+        ...(name && { name }),
+        ...(profile && { photo: profile }),
+        ...(schoolId && { schoolId }),
+      },
+    });
+    return user;
+  };
 }
 export default UserRepository;

--- a/src/routers/user.router.js
+++ b/src/routers/user.router.js
@@ -34,4 +34,12 @@ userRouter.patch(
   verifySchoolUser,
   userController.updateMyPassword,
 );
+
+// 내 정보 수정 ( 학교, 이름, 사진 변경 )
+userRouter.patch(
+  '/me',
+  requireAccessToken(''),
+  verifySchoolUser,
+  userController.updateMyInfo,
+);
 export { userRouter };

--- a/src/services/students.service.js
+++ b/src/services/students.service.js
@@ -1,10 +1,11 @@
 import { MESSAGES } from '../constants/message.constant.js';
 import { NotFoundError } from '../errors/http.error.js';
+import ClassRepository from '../repositories/class.repository.js';
 import StudentsRepository from '../repositories/students.repository.js';
 
 class StudentsService {
   studentsRepository = new StudentsRepository();
-
+  classRepository = new ClassRepository();
   //반 학생 목록 조회
   getClassStudent = async (classId, schoolId) => {
     const data = await this.studentsRepository.getClassStudent(
@@ -25,19 +26,35 @@ class StudentsService {
   };
 
   //특정 학생 정보 수정
-  updateOneStudent = async (studentId, name, grade, gradeClass, number) => {
+  updateOneStudent = async (
+    studentId,
+    name,
+    grade,
+    gradeClass,
+    number,
+    schoolId,
+  ) => {
     //유효성 검사 추가
     const student = await this.studentsRepository.getOneStudent(studentId);
     if (!student) {
       throw new NotFoundError(MESSAGES.STUDENT.COMMON.NOT_FOUND);
     }
-
+    const classByGradeAndClass =
+      await this.classRepository.findClassByGradeAndClass(
+        grade,
+        gradeClass,
+        schoolId,
+      );
+    if (!classByGradeAndClass) {
+      throw new NotFoundError('해당 반이 존재하지 않습니다.');
+    }
     const data = await this.studentsRepository.updateOneStudent(
       studentId,
       name,
       grade,
       gradeClass,
       number,
+      classByGradeAndClass.classId,
     );
     return data;
   };

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -4,10 +4,11 @@ import { NotFoundError } from '../errors/http.error.js';
 import UserRepository from '../repositories/user.repository.js';
 import TeacherRepository from '../repositories/teacher.repository.js';
 import bcrypt from 'bcrypt';
+import SchoolRepository from '../repositories/school.repository.js';
 class UserService {
   userRepository = new UserRepository();
   teacherRepository = new TeacherRepository();
-
+  schoolRepository = new SchoolRepository();
   // 담임 설정 및 반 생성
   assignHomeRoom = async (grade, gradeClass, userId) => {
     // 반에 담임이 이미 존재한다면 에러 반환
@@ -50,6 +51,23 @@ class UserService {
     );
     if (!updatedUser) throw new Error('유저를 찾을 수 없습니다.');
     return;
+  };
+
+  // 내 정보 수정
+  updateMyInfo = async (userId, name, schoolName, profile) => {
+    const user = await this.userRepository.getUserById(userId);
+    if (!user) throw new NotFoundError('유저를 찾을 수 없습니다.');
+    const school = schoolName
+      ? await this.schoolRepository.findSchoolBySchoolName(schoolName)
+      : null;
+
+    const updatedUser = await this.userRepository.updateMyInfo(
+      userId,
+      name,
+      profile,
+      school ? school[0].schoolId : null,
+    );
+    return updatedUser;
   };
 }
 


### PR DESCRIPTION
## 📝 변경 사항  
[//]: # (이 PR에서 수행된 변경 사항에 대해 설명)  
- 학생 정보 수정 API 에러
상황 : 학생의 반이 바뀌어도 다른 반 학생목록에 출력이 되는 문제
문제 : 학생의 반, 번호를 바꿔도 classId가 바뀌지 않는 문제

- 개인 정보 수정 API 추가
( 학교, 이름, 사진 ) 변경 가능하게 구현

- 담임 설정 API 로직 추가
기존 : 담임이 존재할 때, 담임 설정 API 실행 시 에러 반환
현재 : 담임이 존재할 때, 담임 교체 API 추가
  
## 🔍 관련 이슈  
- 이 PR이 해결하는 이슈: #74 
  
## ✅ 테스트 결과  
- [x] 기능 테스트 완료  
- [x] 버그 테스트 완료  
  
## 📌 추가 사항  
- <추가로 고려해야 할 사항>
