### PR TITLE
96 feat 동시성 처리

### DIFF
--- a/src/repositories/grades.repository.js
+++ b/src/repositories/grades.repository.js
@@ -6,17 +6,17 @@ class GradesRepository {
     const data = await prisma.grade.createMany({
       data: gradesWithStudentId,
     });
-    
+
     const schoolYear = gradesWithStudentId[0].schoolYear;
     const semester = gradesWithStudentId[0].semester;
 
     const notification = await prisma.notification.create({
-      data : {
+      data: {
         userId: studentUserId,
-        type:"GRADE",
-        message: `${schoolYear}학년 ${semester}학기 생성`
-      }
-    })
+        type: 'GRADE',
+        message: `${schoolYear}학년 ${semester}학기 생성`,
+      },
+    });
 
     return data;
   };
@@ -46,31 +46,43 @@ class GradesRepository {
 
   // 성적 수정
   updateGrades = async (gradesWithStudentId, studentUserId) => {
-    const grades = gradesWithStudentId.map((grade) =>
-      prisma.grade.updateMany({
-        where: {
-          studentId: grade.studentId,
-          schoolYear: grade.schoolYear,
-          semester: grade.semester,
-          subject: grade.subject,
-        },
-        data: {
-          scoreIv: grade.scoreIv,
-          scoreContent: grade.scoreContent,
-        },
-      }),
-    );
+    await prisma.$transaction(async (tx) => {
+      const results = await Promise.all(
+        gradesWithStudentId.map((grade) =>
+          tx.grade.updateMany({
+            where: {
+              studentId: grade.studentId,
+              schoolYear: grade.schoolYear,
+              semester: grade.semester,
+              subject: grade.subject,
+              updatedAt: grade.updatedAt, // 낙관적 락용
+            },
+            data: {
+              scoreIv: grade.scoreIv,
+              scoreContent: grade.scoreContent,
+              updatedAt: new Date(),
+            },
+          }),
+        ),
+      );
+
+      //  하나라도 수정되지 않았다면 트랜잭션 전체 취소
+      const failed = results.find((res) => res.count === 0);
+      if (failed) {
+        throw new Error('다른 탭 혹은 창에서 이미 수정되었습니다.');
+      }
+    });
     const schoolYear = gradesWithStudentId[0].schoolYear;
     const semester = gradesWithStudentId[0].semester;
     const notification = await prisma.notification.create({
-      data : {
+      data: {
         userId: studentUserId,
-        type:"GRADE",
-        message: `${schoolYear}학년 ${semester}학기 업데이트`
-      }
-    })
-    const results = await Promise.all(grades);
-    return results;
+        type: 'GRADE',
+        message: `${schoolYear}학년 ${semester}학기 업데이트`,
+      },
+    });
+
+    return;
   };
 
   // 특정 기간에 맞는 특정 과목 성적 조회

--- a/src/services/feedback.service.js
+++ b/src/services/feedback.service.js
@@ -68,6 +68,9 @@ class FeedbackService {
           `카테고리가 없거나 유효하지 않은 카테고리입니다: ${item.category}`,
         );
       }
+      if (!item.updatedAt) {
+        throw new BadRequestError(`업데이트 날짜가 없습니다: ${item.category}`);
+      }
     }
 
     const hasRequiredData = studentId && feedback && schoolYear;

--- a/src/services/grades.service.js
+++ b/src/services/grades.service.js
@@ -103,9 +103,18 @@ class GradesService {
   // 성적 수정
   updateGrades = async (gradesWithStudentId) => {
     // 유효성 검사
+    console.log(gradesWithStudentId);
     for (const item of gradesWithStudentId) {
-      const { schoolYear, semester, subject, score, studentId } = item;
-      if (!schoolYear || !semester || !subject || !score || !studentId) {
+      const { schoolYear, semester, subject, score, studentId, updatedAt } =
+        item;
+      if (
+        !schoolYear ||
+        !semester ||
+        !subject ||
+        !score ||
+        !studentId ||
+        !updatedAt
+      ) {
         throw new NotFoundError('값을 불러오지 못했습니다.');
       }
       const encryptedGrades = encrypt(score);


### PR DESCRIPTION
## 📝 변경 사항  
[//]: # (이 PR에서 수행된 변경 사항에 대해 설명)  

동시성 제어를 위해 '낙관적 락' 적용
적용된 API : 성적 수정 / 피드백 수정 / 상담 수정 ( 이건 API가 없어서 구현 X )
  
prisma transaction를 활용해
하나의 데이터가 사용자가 클릭한 시점의 updatedAt과 값이 다르다면 에러반환  

` await prisma.$transaction(async (tx) => {
      const results = await Promise.all(
        feedback.map((item) =>
          tx.feedback.updateMany({
            where: {
              studentId,
              schoolYear,
              category: item.category,
              updatedAt: item.updatedAt, // 낙관적 락용
            },
            data: {
              content: item.content,
            },
          }),
        ),
      );
      console.log(results);
      //  하나라도 수정되지 않았다면 트랜잭션 전체 취소
      const failed = results.find((res) => res.count === 0);
      if (failed) {
        throw new Error('다른 탭 혹은 창에서 이미 수정되었습니다.');
      } `

## 🔍 관련 이슈  
- 이 PR이 해결하는 이슈: #96 
  
## ✅ 테스트 결과  
- [ ] 기능 테스트 완료  
- [ ] 버그 테스트 완료  
  
## 📌 추가 사항  
- <추가로 고려해야 할 사항>
